### PR TITLE
Fix spelling errors, remove an uneeded =

### DIFF
--- a/docs/pages/manual/build/Hydra/introduction.md
+++ b/docs/pages/manual/build/Hydra/introduction.md
@@ -31,7 +31,7 @@ Hovering an image with your mouse will show a zoom icon <i class="bi bi-zoom-in"
 
 | :-------------------------: | :--------------------       | -------------------------------------------------------------------------------: |
 | Tool<br>Description| Soldering iron<br>Used for heat set inserts |     [![soldering iron](../../../../assets/images/tools/soldering_iron.png)](#lightbox__item_1){: .lightbox_wrapper} |
-| Tool<br>Description<br>Sizes| Hex Keys<br>Used to tighten and losen bolts<br>2mm, 2.5mm, 3mm, 4mm|     [![soldering iron](../../../../assets/images/tools/wera_hexkeys.png)](#lightbox__item_2){: .lightbox_wrapper} |
+| Tool<br>Description<br>Sizes| Hex Keys<br>Used to tighten and loosen bolts<br>2mm, 2.5mm, 3mm, 4mm|     [![soldering iron](../../../../assets/images/tools/wera_hexkeys.png)](#lightbox__item_2){: .lightbox_wrapper} |
 {: class="hardwaretable"}
 
 <div onclick="location.href='##';"  id="lightbox__item_1"  class="lightbox__item">

--- a/docs/pages/manual/build/mercury_one_1/sanding_pins.md
+++ b/docs/pages/manual/build/mercury_one_1/sanding_pins.md
@@ -17,11 +17,11 @@ img_instr_ls: ../../../assets/images/instructions/assembly/left_stepper
 
 ### Why do I have to sand my dowel pins?
 
-If they do fit nicely you do not need to sand them down.=
+If they do fit nicely you do not need to sand them down.
 
 #### Prior to assembly
 
-Test fit your dowel pin in the F695-2RS 5\*13\*4 Mm bearing, if they're tight **DO NOT** continue. You want to sand them down a little. 
+Test fit your dowel pin in the F695-2RS 5\*13\*4 mm bearing, if they're tight **DO NOT** continue. You want to sand them down a little. 
 
 
 #### Forcing your dowel pins

--- a/docs/pages/manual/howto_print_abs.md
+++ b/docs/pages/manual/howto_print_abs.md
@@ -13,7 +13,7 @@ permalink: "/manual/print/abs"
 ### What material should I use?
 ZeroG printers are designed to be printed using ABS or ASA. This means we've included tolerances for material shrinkage in our models.
 
-It's recommended to print your ABS or ASA parts inside of an enclosure, this will greatly increase layer strenght.
+It's recommended to print your ABS or ASA parts inside of an enclosure, this will greatly increase layer strength.
 
 {: .note}
 We find that parts printed in ABS+ are **weaker in layer adhesion** compared to non ABS+ filaments. Although easier to print, they're **easier to break**.

--- a/docs/pages/standard/standard_cad.md
+++ b/docs/pages/standard/standard_cad.md
@@ -17,18 +17,18 @@ This page includes the clearances you need when printing with ABS, they have bee
 
 |         Type |  Fit  | Hole  | Counterbore | Depth |
 | -----------: | :---: | :---: | :---------- | :---- |
-|       DIN918 | Lose  | 3.3mm | 6mm         | N/A   |
+|       DIN918 | Loose | 3.3mm | 6mm         | N/A   |
 |       DIN918 | Tight | 3.2mm | 5.8mm       | N/A   |
-| DIN934 (nut) | Lose  | 5.8mm | N/A         | 2.6mm |
+| DIN934 (nut) | Loos  | 5.8mm | N/A         | 2.6mm |
 | DIN934 (nut) | Tight | 5.7mm | N/A         | 2.6mm |
 
 ### M5 hardware
 
 |         Type |  Fit  | Hole  | Counterbore | Depth |
 | -----------: | :---: | :---: | :---------- | :---- |
-|       DIN918 | Lose  | 5.3mm | 9mm         | N/A   |
+|       DIN918 | Loose | 5.3mm | 9mm         | N/A   |
 |       DIN918 | Tight | 5.2mm | 8.8mm       | N/A   |
-| DIN934 (nut) | Lose  | 8.3mm | N/A         | 4.2mm |
+| DIN934 (nut) | Loose | 8.3mm | N/A         | 4.2mm |
 | DIN934 (nut) | Tight | 8.2mm | N/A         | 4.2mm |
 
 

--- a/docs/pages/standard/standard_cad.md
+++ b/docs/pages/standard/standard_cad.md
@@ -19,7 +19,7 @@ This page includes the clearances you need when printing with ABS, they have bee
 | -----------: | :---: | :---: | :---------- | :---- |
 |       DIN918 | Loose | 3.3mm | 6mm         | N/A   |
 |       DIN918 | Tight | 3.2mm | 5.8mm       | N/A   |
-| DIN934 (nut) | Loos  | 5.8mm | N/A         | 2.6mm |
+| DIN934 (nut) | Loose | 5.8mm | N/A         | 2.6mm |
 | DIN934 (nut) | Tight | 5.7mm | N/A         | 2.6mm |
 
 ### M5 hardware

--- a/docs/pages/standard/standard_print.md
+++ b/docs/pages/standard/standard_print.md
@@ -14,7 +14,7 @@ We've designed our parts to work with the settings displayed below. Make sure to
 If you're not happy with the print quality, join our [Discord](https://discord.gg/zerog){:target="_blank"} and ask for some help.
 
 ### Recommended print settings
-* First layer height 0.25mm (Yes, you have too... Our parts have been designed for this)
+* First layer height 0.25mm (Yes, you have to... Our parts have been designed for this)
 * Layer height: 0.2mm
 * Extrusion width: 0.4mm, forced
 * Infill pecentage: 40%


### PR DESCRIPTION
Fixed a few minor spelling errors and removed an unneeded `=` on line 20 of the sanding_pins.md